### PR TITLE
Specify node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   tests:
     docker:
-      - image: circleci/node:latest-browsers
+      - image: circleci/node:16-browsers
     working_directory: ~/repo
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11 as builder
+FROM node:16 as builder
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ RUN yarn build
 
 FROM nginx:1.17-alpine
 
-MAINTAINER Peder Smith <smithpeder@gmail.com>
+LABEL org.opencontianers.image.authors="web@itdagene.no"
 
 COPY --from=builder /app/build /usr/share/nginx/html
 


### PR DESCRIPTION
node:latest-browsers is now node 17, and would therefore fail the build