### PR TITLE
Fix bug related to regex validation

### DIFF
--- a/src/components/InterestForm.tsx
+++ b/src/components/InterestForm.tsx
@@ -41,7 +41,7 @@ const initialValues: FormValues = {
   english: false,
 };
 
-const regex = /^([A-Z,a-z,0-9,(,),-,_,&,.,.,,!,?])/;
+const regex = /^([ÆØÅæøåA-Z,a-z,0-9,(,),-,_,&,.,.,,!,?])/;
 
 const validationSchema = Yup.object().shape({
   companyName: Yup.string()


### PR DESCRIPTION
Resolves #180 

The bug was only relevant for names _beginning_ with ÆØÅ, and affected both the Company name and Contact person name fields. I simply changed the regex to accommodate the letters.